### PR TITLE
Fixing rviz view_cameras.rviz configuration

### DIFF
--- a/ucf_core/src/core_sensors/core_sparton/CMakeLists.txt
+++ b/ucf_core/src/core_sensors/core_sparton/CMakeLists.txt
@@ -1,0 +1,164 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(core_sparton)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  rospy
+  sensor_msgs
+  std_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   geometry_msgs#   sensor_msgs#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES core_sparton
+#  CATKIN_DEPENDS geometry_msgs rospy sensor_msgs std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(core_sparton
+#   src/${PROJECT_NAME}/core_sparton.cpp
+# )
+
+## Declare a cpp executable
+# add_executable(core_sparton_node src/core_sparton_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(core_sparton_node core_sparton_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(core_sparton_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS core_sparton core_sparton_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_core_sparton.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/ucf_core/src/core_sensors/core_sparton/launch/AHRS-8.launch
+++ b/ucf_core/src/core_sensors/core_sparton/launch/AHRS-8.launch
@@ -1,0 +1,7 @@
+<!-- Launch file to bring up serial communications with the AHRS-8 -->
+<launch>
+    <node name="ahrs8" pkg="core_sparton" type="ahrs8_nmea.py">
+        <param name="port" value="/dev/ttyUSB0"/>
+        <param name="baud" value="115200"/>
+    </node>
+</launch>

--- a/ucf_core/src/core_sensors/core_sparton/package.xml
+++ b/ucf_core/src/core_sensors/core_sparton/package.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<package>
+  <name>core_sparton</name>
+  <version>0.0.0</version>
+  <description>The core_sparton package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="kenneth@todo.todo">kenneth</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/core_sparton</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/ucf_core/src/core_sensors/core_sparton/src/ahrs8_nmea.py
+++ b/ucf_core/src/core_sensors/core_sparton/src/ahrs8_nmea.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+
+import rospy
+import serial, math
+from geometry_msgs.msg import Quaternion
+from sensor_msgs.msg import Imu
+
+import tf
+from tf.transformations import euler_from_quaternion, quaternion_from_euler
+
+# Verify the checksum obtained in the NMEA message.
+def verify_checksum(response):
+    # strip leading $
+    message_and_checksum = response.strip("$")
+    # split into message text and trailing checksum as a 2-tuple
+    message_and_checksum = message_and_checksum.split("*")
+    # message text is first component, checksum second.  Make sure we strip whitespace.
+    message = message_and_checksum[0]
+    checksum = message_and_checksum[1].strip()
+
+    calculated_checksum = 0
+
+    # NMEA checksums are obtained by xor'ing the ascii value of every character between $ and *
+    for character in message:
+        calculated_checksum = calculated_checksum ^ ord(character)
+
+    # Get the 2 digit hex representation of the result.
+    hexstring = format(calculated_checksum, "02X")
+    # Return if the checksums match or not.
+    return hexstring == checksum
+
+# Populate message angular velocity values.
+def populate_G(string, message):
+    split_string = string.split(",")
+    # Split off each value expression "<a>=<value>" as a string.
+    Gx_string = split_string[1]
+    Gy_string = split_string[2]
+    # Split checksum off of last output string.
+    Gz_string = split_string[3].split("*")[0]
+
+    # Parse the angular velocity values.
+    Gx_float = millidegrees_to_radians(float(Gx_string.split("=")[1]))
+    Gy_float = millidegrees_to_radians(float(Gy_string.split("=")[1]))
+    Gz_float = millidegrees_to_radians(float(Gz_string.split("=")[1]))
+
+    # Populate the message using X FORWARD Y LEFT Z UP
+    message.angular_velocity.x = Gx_float
+    message.angular_velocity.y = -Gy_float
+    message.angular_velocity.z = -Gz_float
+
+# Populate message quaternion data
+def populate_QUAT(string, message):
+    split_string = string.split(",")
+    # Split off each value expression "<a>=<value>" as a string.
+    w_string = split_string[1]
+    x_string = split_string[2]
+    y_string = split_string[3]
+    # Split checksum off of last output string.
+    z_string = split_string[4].split("*")[0]
+
+    # Parse the quaternion values.
+    w_float = float(w_string.split("=")[1])
+    x_float = float(x_string.split("=")[1])
+    y_float = float(y_string.split("=")[1])
+    z_float = float(z_string.split("=")[1])
+
+    # Build euler angle array (r,p,y) from quaternion using ENU convention.
+    euler = euler_from_quaternion([y_float, x_float, -z_float, w_float])
+
+    # Reference is still 0 yaw facing north, -pi/2 East.  Add pi/2 to zero yaw when facing East.
+    # Get new quaternion from this modification. Returned as (x, y, z, w)
+    quat = quaternion_from_euler(euler[0], euler[1], euler[2] + math.pi/2)
+
+    # Populate IMU message using ENU coordinate convention.
+    message.orientation.w = quat[3]
+    message.orientation.x = quat[0]
+    message.orientation.y = quat[1]
+    message.orientation.z = quat[2]
+
+# Populate linear acceleration data.
+def populate_A(string, message):
+    split_string = string.split(",")
+    # Split off each value expression "<a>=<value>" as a string.
+    Ax_string = split_string[1]
+    Ay_string = split_string[2]
+    # Split checksum off of last output string.
+    Az_string = split_string[3].split("*")[0]
+
+    # Parse the linear acceleration values.
+    Ax_float = millig_to_meter(float(Ax_string.split("=")[1]))
+    Ay_float = millig_to_meter(float(Ay_string.split("=")[1]))
+    Az_float = millig_to_meter(float(Az_string.split("=")[1]))
+
+    # Populate the message using X FORWARD Y LEFT Z UP
+    message.linear_acceleration.x = -Ax_float
+    message.linear_acceleration.y = Ay_float
+    message.linear_acceleration.z = Az_float
+
+def millidegrees_to_radians(value):
+    return (value/1000) * (math.pi/180.0)
+
+def millig_to_meter(value):
+    return (value/1000) * 9.81
+
+# Set all covariance matrices to one matrix.
+# Only needed until we understand better how to deal with the covariance of each data set.
+def set_all_covariance(imu_msg, covariance_matrix):
+    # Copy covariance_matrix to each imu_msg covariance
+    for i in range(0, 9):
+        imu_msg.orientation_covariance[i] = covariance_matrix[i]
+        imu_msg.angular_velocity_covariance[i] = covariance_matrix[i]
+        imu_msg.linear_acceleration_covariance[i] = covariance_matrix[i]
+
+if __name__ == '__main__':
+    rospy.loginfo("Why isn't this working?")
+    # Initialize node
+    rospy.init_node("ahrs8_node")
+    # Initialize publisher
+    imu_pub = rospy.Publisher("imu/data", Imu, queue_size=10)
+    imu_msg = Imu()
+
+    # Set IMU device transform frame.
+    imu_msg.header.frame_id = "placeholder"
+
+    # Default matrix to use for covariance of each measurement set.
+    default_covariance_matrix = [1e-6, 0, 0,
+                                 0, 1e-6, 0,
+                                 0, 0, 1e-6]
+
+    # Populate the imu message with the covariance matrix.
+    set_all_covariance(imu_msg, default_covariance_matrix)
+    
+    default_port = "/dev/ttyUSB0"
+    default_baud = 115200
+    compass_port = rospy.get_param("~port", default_port)
+    compass_baud = rospy.get_param("~baud", default_baud)
+
+    compass_serial = serial.Serial(compass_port, compass_baud, timeout=1)
+
+    try:
+        # Clear all repeating I/O that could be leftover from operation.
+        compass_serial.write("\x13")
+        compass_serial.write("$xxHDM\r\n")
+        compass_serial.write("printmask 0 set drop\r\n")
+        compass_serial.write("printmodulus 0 set drop\r\n")
+        compass_serial.write("printtrigger 0 set drop\r\n")
+
+        rospy.sleep(0.1)
+        # Resume output allowed. Ctrl-Q
+        compass_serial.write("\x11")
+        rospy.sleep(0.1)
+        # Flush all buffers.
+        compass_serial.flushInput()
+        compass_serial.flushOutput()
+        rospy.sleep(0.1)
+    except serial.SerialException:
+        rospy.logerr("AHRS-8: Serial communications not opened properly!")
+
+    rospy.loginfo("AHRS-8: Output reset, beginning to retrieve data.")
+
+    while not rospy.is_shutdown():
+        # Get angular velocity
+        compass_serial.write("$PSPA,G\r\n")
+        response = compass_serial.readline()
+        if (verify_checksum(response)):
+            populate_G(response, imu_msg)
+        else:
+            rospy.logerr("AHRS-8: Bad checksum, skipping dataset.")
+            continue
+
+        # Get orientation in ENU convention with East as 0 yaw reference.
+        compass_serial.write("$PSPA,QUAT\r\n")
+        response = compass_serial.readline()
+        if (verify_checksum(response)):
+            populate_QUAT(response, imu_msg)
+        else:
+            rospy.logerr("AHRS-8: Bad checksum, skipping dataset.")
+            continue
+
+        # Get linear acceleration.
+        compass_serial.write("$PSPA,A\r\n")
+        response = compass_serial.readline()
+        if (verify_checksum(response)):
+            populate_A(response, imu_msg)
+        else:
+            rospy.logerr("AHRS-8: Bad checksum, skipping dataset.")
+            continue
+
+        # Publish the current message.
+        imu_pub.publish(imu_msg)
+        

--- a/ucf_igvc/src/igvc_viz/igvc_rviz/rviz/view_cameras.rviz
+++ b/ucf_igvc/src/igvc_viz/igvc_rviz/rviz/view_cameras.rviz
@@ -5,9 +5,8 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /Status1
       Splitter Ratio: 0.5
-    Tree Height: 372
+    Tree Height: 400
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -26,7 +25,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: Front Camera Raw
+    SyncSource: Front Image Raw
 Visualization Manager:
   Class: ""
   Displays:
@@ -48,63 +47,6 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
-    - Class: rviz/Camera
-      Enabled: true
-      Image Rendering: background and overlay
-      Image Topic: /front_camera/image_raw
-      Name: Front Camera Raw
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Value: true
-      Visibility:
-        Grid: true
-        Left Camera Raw: true
-        Local Costmap: true
-        Map: true
-        Odometry: true
-        Right Camera Raw: true
-        RobotModel: true
-        Value: true
-      Zoom Factor: 1
-    - Class: rviz/Camera
-      Enabled: true
-      Image Rendering: background and overlay
-      Image Topic: /left_camera/image_raw
-      Name: Left Camera Raw
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Value: true
-      Visibility:
-        Front Camera Raw: true
-        Grid: true
-        Local Costmap: true
-        Map: true
-        Odometry: true
-        Right Camera Raw: true
-        RobotModel: true
-        Value: true
-      Zoom Factor: 1
-    - Class: rviz/Camera
-      Enabled: true
-      Image Rendering: background and overlay
-      Image Topic: /right_camera/image_raw
-      Name: Right Camera Raw
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Value: true
-      Visibility:
-        Front Camera Raw: true
-        Grid: true
-        Left Camera Raw: true
-        Local Costmap: true
-        Map: true
-        Odometry: true
-        RobotModel: true
-        Value: true
-      Zoom Factor: 1
     - Alpha: 0.7
       Class: rviz/Map
       Color Scheme: map
@@ -121,31 +63,143 @@ Visualization Manager:
       Name: Local Costmap
       Topic: /move_base/local_costmap/costmap
       Value: true
-    - Angle Tolerance: 0.1
-      Class: rviz/Odometry
-      Color: 255; 25; 0
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
       Enabled: true
-      Keep: 1
-      Length: 1
-      Name: Odometry
-      Position Tolerance: 0.1
-      Topic: /odom
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 999999
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.01
+      Style: Flat Squares
+      Topic: /scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /front_camera/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Front Image Raw
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /left_camera/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Left Image Raw
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /right_camera/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Right Image Raw
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
       Value: true
     - Alpha: 1
       Class: rviz/RobotModel
       Collision Enabled: false
-      Enabled: false
+      Enabled: true
       Links:
         All Links Enabled: true
         Expand Joint Details: false
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_laser:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_camera:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_camera:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_caster_rotator:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_caster_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_camera:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_caster_rotator:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_caster_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
       Name: RobotModel
       Robot Description: robot_description
       TF Prefix: ""
       Update Interval: 0
-      Value: false
+      Value: true
       Visual Enabled: true
   Enabled: true
   Global Options:
@@ -178,27 +232,33 @@ Visualization Manager:
         Value: false
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.340398
+      Pitch: 0.3
       Position:
-        X: -9.41314
-        Y: 0.0105938
-        Z: 3.08767
+        X: -7.7999
+        Y: -0.046704
+        Z: 3
       Target Frame: base_footprint
       Value: FPS (rviz)
-      Yaw: 6.28199
+      Yaw: 0
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
   Front Camera Raw:
     collapsed: false
+  Front Image Raw:
+    collapsed: false
   Height: 1056
   Hide Left Dock: false
   Hide Right Dock: false
   Left Camera Raw:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000017200000203fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000001bb00000203000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000016b00000203fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000001bb00000203000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000073f0000018dfc0100000004fb0000001e004c006500660074002000430061006d0065007200610020005200610077010000000000000269000000a600fffffffb0000002000460072006f006e0074002000430061006d0065007200610020005200610077010000026f00000268000000af00fffffffb0000002000520069006700680074002000430061006d006500720061002000520061007701000004dd00000262000000ae00fffffffb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000003efc0100000002fb0000000800540069006d006501000000000000073f000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000004560000020300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Left Image Raw:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001720000021ffc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000019f0000021f000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000016b0000021ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000019f0000021f000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000073f00000171fc0100000006fb0000001e004c006500660074002000430061006d00650072006100200052006100770000000000000003a2000000a6000000a6fb0000001c004c00650066007400200049006d00610067006500200052006100770100000000000002680000009c00fffffffc0000026e00000264000000a500fffffffa000000000200000002fb0000001e00460072006f006e007400200049006d00610067006500200052006100770100000000ffffffff0000001600fffffffb0000002000460072006f006e0074002000430061006d00650072006100200052006100770000000028000000160000001600000016fb0000001e0052006900670068007400200049006d006100670065002000520061007701000004d800000267000000a400fffffffb0000002000520069006700680074002000430061006d006500720061002000520061007700000000000000073f000000ae000000aefb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000003efc0100000002fb0000000800540069006d006501000000000000073f000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000004560000021f00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Right Camera Raw:
+    collapsed: false
+  Right Image Raw:
     collapsed: false
   Selection:
     collapsed: false


### PR DESCRIPTION
Updated configuration file to use images in the camera image view
instead of cameras.  Allows us to view the robot model without pieces
of the model appearing in the image in rviz